### PR TITLE
Fix for index out of range issue while multiple goroutines update Conns array

### DIFF
--- a/s5.go
+++ b/s5.go
@@ -259,8 +259,10 @@ func handleConnection(conn net.Conn) {
 	defer func() {
 		for i, c := range Conns {
 			if c == conn {
-				Conns = append(Conns[:i], Conns[i+1:]...)
+				Conns[i] = Conns[len(Conns)-1]
+				Conns = Conns[:len(Conns)-1]
 			}
+			recover()
 		}
 		conn.Close()
 	}()


### PR DESCRIPTION
Hi Im using this socks5 proxy for some homemade things, but I was getting issues because of concurrency of goroutines updating a global variable (Conns array), I fixed the issue by adding mutex locks and also controlling errors using recover. Please review and merge. 